### PR TITLE
Add multi-provider support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: go
+go: 1.6
+
+services:
+- redis
+
+env:
+  global:
+    - REDIS_URL="redis://"
+
+addons:
+  postgresql: "9.4"
+
+install:
+- go get github.com/FiloSottile/gvt
+- go get -u github.com/alecthomas/gometalinter
+- gometalinter --install --update
+
+script:
+  - make deps
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PACKAGES := \
+	github.com/travis-ci/cloud-brain/cbcontext \
+	github.com/travis-ci/cloud-brain/cloud \
+	github.com/travis-ci/cloud-brain/cloudbrain \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-create-token \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-create-worker \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-http \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-refresh-worker \
+	github.com/travis-ci/cloud-brain/database \
+	github.com/travis-ci/cloud-brain/http \
+	github.com/travis-ci/cloud-brain/worker
+
+.PHONY: test
+test: deps
+	go test $(PACKAGES)
+
+deps: vendor/.deps-fetched
+
+vendor/.deps-fetched:
+	gvt rebuild
+	touch $@
+
+.PHONY: list-deps
+list-deps:
+	go list -f '{{ join .Imports "\n" }}' $(PACKAGES) | sort | uniq

--- a/cloud/fake_test.go
+++ b/cloud/fake_test.go
@@ -8,22 +8,25 @@ var _ Provider = &FakeProvider{}
 func TestFakeProviderCreate(t *testing.T) {
 	provider := &FakeProvider{}
 
-	_, err := provider.Create(CreateAttributes{ImageName: ""})
+	_, err := provider.Create("no-image-name", CreateAttributes{ImageName: ""})
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
 
-	_, err = provider.Create(CreateAttributes{ImageName: "nonexistant-image"})
+	_, err = provider.Create("invalid-image-name", CreateAttributes{ImageName: "nonexistant-image"})
 	if err == nil {
 		t.Errorf("expected error, got nil")
 	}
 
-	instance, err := provider.Create(CreateAttributes{ImageName: "standard-image"})
+	instance, err := provider.Create("valid-image-name", CreateAttributes{ImageName: "standard-image"})
 	if err != nil {
 		t.Errorf("provider.Create returned error: %v", err)
 	}
 
 	if instance.State != InstanceStateStarting {
 		t.Errorf("expected state to be %v, was %v", InstanceStateStarting, instance.State)
+	}
+	if instance.ID != "valid-image-name" {
+		t.Errorf("expected ID to be %v, was %v", "valid-image-name", instance.ID)
 	}
 }

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -63,14 +63,14 @@ type gceInstanceConfig struct {
 	Preemptible        bool
 }
 
-type gceAccountJSON struct {
+type GCEAccountJSON struct {
 	ClientEmail string `json:"client_email"`
 	PrivateKey  string `json:"private_key"`
 	TokenURI    string `json:"token_uri"`
 }
 
 type GCEProviderConfiguration struct {
-	AccountJSON         gceAccountJSON `json:"account_json"`
+	AccountJSON         GCEAccountJSON `json:"account_json"`
 	ProjectID           string         `json:"project_id"`
 	ImageProjectID      string         `json:"image_project_id"`
 	Zone                string         `json:"zone"`
@@ -153,7 +153,7 @@ func NewGCEProvider(conf GCEProviderConfiguration) (*GCEProvider, error) {
 	}, nil
 }
 
-func loadGoogleAccountJSON(filenameOrJSON string) (*gceAccountJSON, error) {
+func loadGoogleAccountJSON(filenameOrJSON string) (*GCEAccountJSON, error) {
 	var (
 		reader io.Reader
 		err    error
@@ -171,7 +171,7 @@ func loadGoogleAccountJSON(filenameOrJSON string) (*gceAccountJSON, error) {
 		reader = file
 	}
 
-	a := &gceAccountJSON{}
+	a := &GCEAccountJSON{}
 	err = json.NewDecoder(reader).Decode(a)
 	return a, err
 }

--- a/cloud/registry.go
+++ b/cloud/registry.go
@@ -1,0 +1,40 @@
+package cloud
+
+import (
+	"fmt"
+	"sync"
+)
+
+var (
+	backendRegistry      = map[string]*Backend{}
+	backendRegistryMutex sync.Mutex
+)
+
+type Backend struct {
+	Alias             string
+	HumanReadableName string
+	ProviderFunc      func([]byte) (Provider, error)
+}
+
+func Register(alias, humanReadableName string, providerFunc func([]byte) (Provider, error)) {
+	backendRegistryMutex.Lock()
+	defer backendRegistryMutex.Unlock()
+
+	backendRegistry[alias] = &Backend{
+		Alias:             alias,
+		HumanReadableName: humanReadableName,
+		ProviderFunc:      providerFunc,
+	}
+}
+
+func NewProvider(alias string, cfg []byte) (Provider, error) {
+	backendRegistryMutex.Lock()
+	defer backendRegistryMutex.Unlock()
+
+	backend, ok := backendRegistry[alias]
+	if !ok {
+		return nil, fmt.Errorf("unknown cloud provider: %s", alias)
+	}
+
+	return backend.ProviderFunc(cfg)
+}

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -53,7 +53,7 @@ func (c *Core) GetInstance(ctx context.Context, id string) (*Instance, error) {
 
 	return &Instance{
 		ID:           instance.ID,
-		ProviderName: instance.Provider,
+		ProviderName: instance.ProviderType,
 		Image:        instance.Image,
 		State:        instance.State,
 		IPAddress:    instance.IPAddress,
@@ -71,7 +71,7 @@ type CreateInstanceAttributes struct {
 // create job in the background.
 func (c *Core) CreateInstance(ctx context.Context, providerName string, attr CreateInstanceAttributes) (*Instance, error) {
 	id, err := c.db.CreateInstance(database.Instance{
-		Provider:     providerName,
+		ProviderType: providerName,
 		Image:        attr.ImageName,
 		InstanceType: attr.InstanceType,
 		PublicSSHKey: attr.PublicSSHKey,
@@ -166,7 +166,7 @@ func (c *Core) ProviderRefresh(ctx context.Context) error {
 	}
 
 	for _, instance := range instances {
-		dbInstance, err := c.db.GetInstanceByProviderID(c.cloud.Name(), instance.ID)
+		dbInstance, err := c.db.GetInstance(instance.ID)
 		if err != nil {
 			cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
 				"provider":    c.cloud.Name(),

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -60,7 +60,7 @@ func (c *Core) GetInstance(ctx context.Context, id string) (*Instance, error) {
 
 	return &Instance{
 		ID:           instance.ID,
-		ProviderName: instance.ProviderType,
+		ProviderName: instance.ProviderName,
 		Image:        instance.Image,
 		State:        instance.State,
 		IPAddress:    instance.IPAddress,
@@ -78,7 +78,7 @@ type CreateInstanceAttributes struct {
 // create job in the background.
 func (c *Core) CreateInstance(ctx context.Context, providerName string, attr CreateInstanceAttributes) (*Instance, error) {
 	id, err := c.db.CreateInstance(database.Instance{
-		ProviderType: providerName,
+		ProviderName: providerName,
 		Image:        attr.ImageName,
 		InstanceType: attr.InstanceType,
 		PublicSSHKey: attr.PublicSSHKey,
@@ -145,7 +145,6 @@ func (c *Core) ProviderCreateInstance(ctx context.Context, byteID []byte) error 
 		return err
 	}
 
-	dbInstance.ProviderID = instance.ID
 	dbInstance.State = "starting"
 
 	err = c.db.UpdateInstance(dbInstance)

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -23,19 +23,26 @@ type Core struct {
 
 // TODO(henrikhodne): Is this necessary? Why not just make a Core directly?
 type CoreConfig struct {
-	CloudProvider cloud.Provider
 	DB            database.DB
 	WorkerBackend worker.Backend
 }
 
-func NewCore(conf *CoreConfig) *Core {
-	c := &Core{
-		cloud: conf.CloudProvider,
-		db:    conf.DB,
-		wb:    conf.WorkerBackend,
+func NewCore(conf *CoreConfig) (*Core, error) {
+	cloudProviders, err := conf.DB.ListProviders()
+	if err != nil {
+		return nil, err
 	}
 
-	return c
+	cloudProvider, err := cloud.NewProvider(cloudProviders[0].Type, cloudProviders[0].Config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Core{
+		cloud: cloudProvider,
+		db:    conf.DB,
+		wb:    conf.WorkerBackend,
+	}, nil
 }
 
 // GetInstance gets the instance information stored in the database for a given

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -16,9 +16,9 @@ import (
 const MaxCreateRetries = 10
 
 type Core struct {
-	cloud cloud.Provider
-	db    database.DB
-	wb    worker.Backend
+	cloudProviders map[string]cloud.Provider
+	db             database.DB
+	wb             worker.Backend
 }
 
 // TODO(henrikhodne): Is this necessary? Why not just make a Core directly?
@@ -28,20 +28,26 @@ type CoreConfig struct {
 }
 
 func NewCore(conf *CoreConfig) (*Core, error) {
-	cloudProviders, err := conf.DB.ListProviders()
+	dbCloudProviders, err := conf.DB.ListProviders()
 	if err != nil {
 		return nil, err
 	}
 
-	cloudProvider, err := cloud.NewProvider(cloudProviders[0].Type, cloudProviders[0].Config)
-	if err != nil {
-		return nil, err
+	cloudProviders := make(map[string]cloud.Provider)
+
+	for _, dbCloudProvider := range dbCloudProviders {
+		cloudProvider, err := cloud.NewProvider(dbCloudProvider.Type, dbCloudProvider.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		cloudProviders[dbCloudProvider.Name] = cloudProvider
 	}
 
 	return &Core{
-		cloud: cloudProvider,
-		db:    conf.DB,
-		wb:    conf.WorkerBackend,
+		cloudProviders: cloudProviders,
+		db:             conf.DB,
+		wb:             conf.WorkerBackend,
 	}, nil
 }
 
@@ -132,7 +138,16 @@ func (c *Core) ProviderCreateInstance(ctx context.Context, byteID []byte) error 
 		return err
 	}
 
-	instance, err := c.cloud.Create(id, cloud.CreateAttributes{
+	cloudProvider, ok := c.cloudProviders[dbInstance.ProviderName]
+	if !ok {
+		cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+			"instance_id":   id,
+			"provider_name": dbInstance.ProviderName,
+		}).Error("couldn't find provider with given name")
+		return err
+	}
+
+	instance, err := cloudProvider.Create(id, cloud.CreateAttributes{
 		ImageName:    dbInstance.Image,
 		InstanceType: cloud.InstanceType(dbInstance.InstanceType),
 		PublicSSHKey: dbInstance.PublicSSHKey,
@@ -166,38 +181,41 @@ func (c *Core) ProviderCreateInstance(ctx context.Context, byteID []byte) error 
 }
 
 func (c *Core) ProviderRefresh(ctx context.Context) error {
-	instances, err := c.cloud.List()
-	if err != nil {
-		return err
-	}
-
-	for _, instance := range instances {
-		dbInstance, err := c.db.GetInstance(instance.ID)
+	for providerName, cloudProvider := range c.cloudProviders {
+		// TODO(henrikhodne): An error on one provider shouldn't affect other providers
+		instances, err := cloudProvider.List()
 		if err != nil {
-			cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
-				"provider":    c.cloud.Name(),
-				"provider_id": instance.ID,
-			}).Error("failed fetching instance from database")
-			continue
+			return err
 		}
 
-		dbInstance.IPAddress = instance.IPAddress
-		dbInstance.State = string(instance.State)
+		for _, instance := range instances {
+			dbInstance, err := c.db.GetInstance(instance.ID)
+			if err != nil {
+				cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+					"provider_name": providerName,
+					"provider_id":   instance.ID,
+				}).Error("failed fetching instance from database")
+				continue
+			}
 
-		err = c.db.UpdateInstance(dbInstance)
-		if err != nil {
-			cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
-				"provider":    c.cloud.Name(),
-				"provider_id": instance.ID,
-				"db_id":       dbInstance.ID,
-			}).Error("failed to update instance in database")
+			dbInstance.IPAddress = instance.IPAddress
+			dbInstance.State = string(instance.State)
+
+			err = c.db.UpdateInstance(dbInstance)
+			if err != nil {
+				cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+					"provider":    providerName,
+					"provider_id": instance.ID,
+					"db_id":       dbInstance.ID,
+				}).Error("failed to update instance in database")
+			}
 		}
-	}
 
-	cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
-		"provider":       c.cloud.Name(),
-		"instance_count": len(instances),
-	}).Info("refreshed instances")
+		cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+			"provider":       providerName,
+			"instance_count": len(instances),
+		}).Info("refreshed instances")
+	}
 
 	return nil
 }

--- a/cmd/cloudbrain-create-token/main.go
+++ b/cmd/cloudbrain-create-token/main.go
@@ -39,7 +39,7 @@ func mainAction(c *cli.Context) {
 		fmt.Printf("error: could not connect to the database: %v\n", err)
 		return
 	}
-	db := database.NewPostgresDB(pgdb)
+	db := database.NewPostgresDB([32]byte{}, pgdb)
 
 	salt := make([]byte, 32)
 	token := make([]byte, 16)

--- a/cmd/cloudbrain-create-worker/main.go
+++ b/cmd/cloudbrain-create-worker/main.go
@@ -56,66 +56,6 @@ func main() {
 			Usage:  "The URL for the PostgreSQL database to use",
 			EnvVar: "CLOUDBRAIN_DATABASE_URL,DATABASE_URL",
 		},
-		cli.StringFlag{
-			Name:   "gce-account-json",
-			Usage:  "The GCE account JSON blob, or a path pointing to the JSON blob",
-			EnvVar: "CLOUDBRAIN_GCE_ACCOUNT_JSON",
-		},
-		cli.StringFlag{
-			Name:   "gce-project-id",
-			Usage:  "The GCE project ID for the project to boot instances in",
-			EnvVar: "CLOUDBRAIN_GCE_PROJECT_ID",
-		},
-		cli.StringFlag{
-			Name:   "gce-image-project-id",
-			Usage:  "The GCE project ID for the project containing the build environment images",
-			EnvVar: "CLOUDBRAIN_GCE_IMAGE_PROJECT_ID",
-		},
-		cli.StringFlag{
-			Name:   "gce-zone",
-			Usage:  "The GCE zone to boot instances in",
-			Value:  "us-central1-a",
-			EnvVar: "CLOUDBRAIN_GCE_ZONE",
-		},
-		cli.StringFlag{
-			Name:   "gce-standard-machine-type",
-			Usage:  "The machine type to use for 'standard' instances",
-			Value:  "n1-standard-2",
-			EnvVar: "CLOUDBRAIN_GCE_STANDARD_MACHINE_TYPE",
-		},
-		cli.StringFlag{
-			Name:   "gce-premium-machine-type",
-			Usage:  "The machine type to use for 'premium' instances",
-			Value:  "n1-standard-4",
-			EnvVar: "CLOUDBRAIN_GCE_PREMIUM_MACHINE_TYPE",
-		},
-		cli.StringFlag{
-			Name:   "gce-network",
-			Usage:  "The GCE network to connect instances to",
-			Value:  "default",
-			EnvVar: "CLOUDBRAIN_GCE_NETWORK",
-		},
-		cli.IntFlag{
-			Name:   "gce-disk-size",
-			Usage:  "The GCE disk size in GiB",
-			Value:  30,
-			EnvVar: "CLOUDBRAIN_GCE_DISK_SIZE",
-		},
-		cli.BoolFlag{
-			Name:   "gce-auto-implode",
-			Usage:  "Enable to make the instance power off after gce-auto-implode-time if it's still running",
-			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE",
-		},
-		cli.DurationFlag{
-			Name:   "gce-auto-implode-time",
-			Usage:  "How long to wait before auto-imploding. Will be rounded down to the nearest minute.",
-			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE_TIME",
-		},
-		cli.BoolFlag{
-			Name:   "gce-preemptible",
-			Usage:  "Enable to use GCE preemptible instances",
-			EnvVar: "CLOUDBRAIN_GCE_PREEMPTIBLE",
-		},
 	}
 
 	app.Run(os.Args)
@@ -152,21 +92,14 @@ func mainAction(c *cli.Context) {
 	}
 	db := database.NewPostgresDB(pgdb)
 
-	provider, err := cloud.NewGCEProvider(cloud.GCEProviderConfiguration{
-		AccountJSON:         c.String("gce-account-json"),
-		ProjectID:           c.String("gce-project-id"),
-		ImageProjectID:      c.String("gce-image-project-id"),
-		Zone:                c.String("gce-zone"),
-		StandardMachineType: c.String("gce-standard-machine-type"),
-		PremiumMachineType:  c.String("gce-premium-machine-type"),
-		Network:             c.String("gce-network"),
-		DiskSize:            int64(c.Int("gce-disk-size")),
-		AutoImplode:         c.Bool("gce-auto-implode"),
-		AutoImplodeTime:     c.Duration("gce-auto-implode-time"),
-		Preemptible:         c.Bool("gce-preemptible"),
-	})
+	providers, err := db.ListProviders()
 	if err != nil {
-		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't create GCE provider")
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't get provider information from database")
+	}
+
+	provider, err := cloud.NewProvider(providers[0].Type, providers[0].Config)
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't create provider")
 	}
 
 	core := cloudbrain.NewCore(&cloudbrain.CoreConfig{

--- a/cmd/cloudbrain-create-worker/main.go
+++ b/cmd/cloudbrain-create-worker/main.go
@@ -13,7 +13,6 @@ import (
 	"github.com/garyburd/redigo/redis"
 	_ "github.com/lib/pq"
 	"github.com/travis-ci/cloud-brain/cbcontext"
-	"github.com/travis-ci/cloud-brain/cloud"
 	"github.com/travis-ci/cloud-brain/cloudbrain"
 	"github.com/travis-ci/cloud-brain/database"
 	"github.com/travis-ci/cloud-brain/worker"
@@ -106,21 +105,13 @@ func mainAction(c *cli.Context) {
 
 	db := database.NewPostgresDB(encryptionKey, pgdb)
 
-	providers, err := db.ListProviders()
-	if err != nil {
-		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't get provider information from database")
-	}
-
-	provider, err := cloud.NewProvider(providers[0].Type, providers[0].Config)
-	if err != nil {
-		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't create provider")
-	}
-
-	core := cloudbrain.NewCore(&cloudbrain.CoreConfig{
-		CloudProvider: provider,
+	core, err := cloudbrain.NewCore(&cloudbrain.CoreConfig{
 		DB:            db,
 		WorkerBackend: workerBackend,
 	})
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't configure core")
+	}
 
 	err = worker.Run(ctx, "create", workerBackend, worker.WorkerFunc(core.ProviderCreateInstance))
 	if err != nil {

--- a/cmd/cloudbrain-http/main.go
+++ b/cmd/cloudbrain-http/main.go
@@ -110,10 +110,13 @@ func mainAction(c *cli.Context) {
 	}
 	db := database.NewPostgresDB([32]byte{}, pgdb)
 
-	core := cloudbrain.NewCore(&cloudbrain.CoreConfig{
+	core, err := cloudbrain.NewCore(&cloudbrain.CoreConfig{
 		DB:            db,
 		WorkerBackend: workerBackend,
 	})
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't configure core")
+	}
 
 	err = http.ListenAndServe(c.String("addr"), cbhttp.Handler(ctx, core, c.StringSlice("auth-token")))
 	if err != nil {

--- a/cmd/cloudbrain-http/main.go
+++ b/cmd/cloudbrain-http/main.go
@@ -108,7 +108,7 @@ func mainAction(c *cli.Context) {
 	if err != nil {
 		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't connect to postgres")
 	}
-	db := database.NewPostgresDB(pgdb)
+	db := database.NewPostgresDB([32]byte{}, pgdb)
 
 	core := cloudbrain.NewCore(&cloudbrain.CoreConfig{
 		DB:            db,

--- a/cmd/cloudbrain-insert-provider/main.go
+++ b/cmd/cloudbrain-insert-provider/main.go
@@ -30,6 +30,11 @@ func main() {
 			EnvVar: "CLOUDBRAIN_DATABASE_ENCRYPTION_KEY",
 		},
 		cli.StringFlag{
+			Name:   "provider-name",
+			Usage:  "The name to assign to the provider being added",
+			EnvVar: "CLOUDBRAIN_PROVIDER_NAME",
+		},
+		cli.StringFlag{
 			Name:   "gce-account-json",
 			Usage:  "A path pointing to the GCE account JSON file",
 			EnvVar: "CLOUDBRAIN_GCE_ACCOUNT_JSON",
@@ -141,8 +146,15 @@ func mainAction(c *cli.Context) {
 		return
 	}
 
+	providerName := c.String("provider-name")
+	if providerName == "" {
+		fmt.Printf("error: provider name can't be blank\n")
+		return
+	}
+
 	id, err := db.CreateProvider(database.Provider{
 		Type:   "gce",
+		Name:   providerName,
 		Config: jsonConfig,
 	})
 
@@ -151,7 +163,7 @@ func mainAction(c *cli.Context) {
 		return
 	}
 
-	fmt.Printf("created provider with ID %s\n", id)
+	fmt.Printf("created provider %s with ID %s\n", providerName, id)
 }
 
 func loadGoogleAccountJSON(filename string) (cloud.GCEAccountJSON, error) {

--- a/cmd/cloudbrain-insert-provider/main.go
+++ b/cmd/cloudbrain-insert-provider/main.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/codegangsta/cli"
+	_ "github.com/lib/pq"
+	"github.com/travis-ci/cloud-brain/cloud"
+	"github.com/travis-ci/cloud-brain/database"
+)
+
+func main() {
+	app := cli.NewApp()
+	app.Name = "cloudbrain-insert-provider"
+	app.Usage = "Insert configuration for a provider into the database"
+	app.Action = mainAction
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   "database-url",
+			Usage:  "The URL for the PostgreSQL database to use",
+			EnvVar: "CLOUDBRAIN_DATABASE_URL,DATABASE_URL",
+		},
+		cli.StringFlag{
+			Name:   "database-encryption-key",
+			Usage:  "The database encryption key, hex-encoded",
+			EnvVar: "CLOUDBRAIN_DATABASE_ENCRYPTION_KEY",
+		},
+		cli.StringFlag{
+			Name:   "gce-account-json",
+			Usage:  "A path pointing to the GCE account JSON file",
+			EnvVar: "CLOUDBRAIN_GCE_ACCOUNT_JSON",
+		},
+		cli.StringFlag{
+			Name:   "gce-project-id",
+			Usage:  "The GCE project ID for the project to boot instances in",
+			EnvVar: "CLOUDBRAIN_GCE_PROJECT_ID",
+		},
+		cli.StringFlag{
+			Name:   "gce-image-project-id",
+			Usage:  "The GCE project ID for the project containing the build environment images",
+			EnvVar: "CLOUDBRAIN_GCE_IMAGE_PROJECT_ID",
+		},
+		cli.StringFlag{
+			Name:   "gce-zone",
+			Usage:  "The GCE zone to boot instances in",
+			Value:  "us-central1-a",
+			EnvVar: "CLOUDBRAIN_GCE_ZONE",
+		},
+		cli.StringFlag{
+			Name:   "gce-standard-machine-type",
+			Usage:  "The machine type to use for 'standard' instances",
+			Value:  "n1-standard-2",
+			EnvVar: "CLOUDBRAIN_GCE_STANDARD_MACHINE_TYPE",
+		},
+		cli.StringFlag{
+			Name:   "gce-premium-machine-type",
+			Usage:  "The machine type to use for 'premium' instances",
+			Value:  "n1-standard-4",
+			EnvVar: "CLOUDBRAIN_GCE_PREMIUM_MACHINE_TYPE",
+		},
+		cli.StringFlag{
+			Name:   "gce-network",
+			Usage:  "The GCE network to connect instances to",
+			Value:  "default",
+			EnvVar: "CLOUDBRAIN_GCE_NETWORK",
+		},
+		cli.IntFlag{
+			Name:   "gce-disk-size",
+			Usage:  "The GCE disk size in GiB",
+			Value:  30,
+			EnvVar: "CLOUDBRAIN_GCE_DISK_SIZE",
+		},
+		cli.BoolFlag{
+			Name:   "gce-auto-implode",
+			Usage:  "Enable to make the instance power off after gce-auto-implode-time if it's still running",
+			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE",
+		},
+		cli.DurationFlag{
+			Name:   "gce-auto-implode-time",
+			Usage:  "How long to wait before auto-imploding. Will be rounded down to the nearest minute.",
+			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE_TIME",
+		},
+		cli.BoolFlag{
+			Name:   "gce-preemptible",
+			Usage:  "Enable to use GCE preemptible instances",
+			EnvVar: "CLOUDBRAIN_GCE_PREEMPTIBLE",
+		},
+	}
+
+	app.Run(os.Args)
+}
+
+func mainAction(c *cli.Context) {
+	if c.String("database-url") == "" {
+		fmt.Printf("error: the DATABASE_URL environment variable must be set\n")
+		return
+	}
+	pgdb, err := sql.Open("postgres", c.String("database-url"))
+	if err != nil {
+		fmt.Printf("error: could not connect to the database: %v\n", err)
+		return
+	}
+
+	var encryptionKey [32]byte
+	keySlice, err := hex.DecodeString(c.String("database-encryption-key"))
+	if err != nil {
+		fmt.Printf("error: couldn't decode the database encryption key: %v\n", err)
+		return
+	}
+	copy(encryptionKey[:], keySlice[0:32])
+
+	db := database.NewPostgresDB(encryptionKey, pgdb)
+
+	accountJSON, err := loadGoogleAccountJSON(c.String("gce-account-json"))
+	if err != nil {
+		fmt.Printf("error: couldn't load GCE account JSON file: %v\n", err)
+		return
+	}
+
+	providerConfig := cloud.GCEProviderConfiguration{
+		AccountJSON:         accountJSON,
+		ProjectID:           c.String("gce-project-id"),
+		ImageProjectID:      c.String("gce-image-project-id"),
+		Zone:                c.String("gce-zone"),
+		StandardMachineType: c.String("gce-standard-machine-type"),
+		PremiumMachineType:  c.String("gce-premium-machine-type"),
+		Network:             c.String("gce-network"),
+		DiskSize:            int64(c.Int("gce-disk-size")),
+		AutoImplode:         c.Bool("gce-auto-implode"),
+		AutoImplodeTime:     c.Duration("gce-auto-implode-time"),
+		Preemptible:         c.Bool("gce-preemptible"),
+	}
+
+	jsonConfig, err := json.Marshal(providerConfig)
+	if err != nil {
+		fmt.Printf("error: couldn't JSON-encode provider configuration: %v\n", err)
+		return
+	}
+
+	id, err := db.CreateProvider(database.Provider{
+		Type:   "gce",
+		Config: jsonConfig,
+	})
+
+	if err != nil {
+		fmt.Printf("error: couldn't insert provider in database: %v\n", err)
+		return
+	}
+
+	fmt.Printf("created provider with ID %s\n", id)
+}
+
+func loadGoogleAccountJSON(filename string) (cloud.GCEAccountJSON, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return cloud.GCEAccountJSON{}, err
+	}
+	defer file.Close()
+
+	var accountJSON cloud.GCEAccountJSON
+	err = json.NewDecoder(file).Decode(&accountJSON)
+	return accountJSON, err
+}

--- a/cmd/cloudbrain-refresh-worker/main.go
+++ b/cmd/cloudbrain-refresh-worker/main.go
@@ -56,66 +56,6 @@ func main() {
 			Usage:  "The URL for the PostgreSQL database to use",
 			EnvVar: "CLOUDBRAIN_DATABASE_URL,DATABASE_URL",
 		},
-		cli.StringFlag{
-			Name:   "gce-account-json",
-			Usage:  "The GCE account JSON blob, or a path pointing to the JSON blob",
-			EnvVar: "CLOUDBRAIN_GCE_ACCOUNT_JSON",
-		},
-		cli.StringFlag{
-			Name:   "gce-project-id",
-			Usage:  "The GCE project ID for the project to boot instances in",
-			EnvVar: "CLOUDBRAIN_GCE_PROJECT_ID",
-		},
-		cli.StringFlag{
-			Name:   "gce-image-project-id",
-			Usage:  "The GCE project ID for the project containing the build environment images",
-			EnvVar: "CLOUDBRAIN_GCE_IMAGE_PROJECT_ID",
-		},
-		cli.StringFlag{
-			Name:   "gce-zone",
-			Usage:  "The GCE zone to boot instances in",
-			Value:  "us-central1-a",
-			EnvVar: "CLOUDBRAIN_GCE_ZONE",
-		},
-		cli.StringFlag{
-			Name:   "gce-standard-machine-type",
-			Usage:  "The machine type to use for 'standard' instances",
-			Value:  "n1-standard-2",
-			EnvVar: "CLOUDBRAIN_GCE_STANDARD_MACHINE_TYPE",
-		},
-		cli.StringFlag{
-			Name:   "gce-premium-machine-type",
-			Usage:  "The machine type to use for 'premium' instances",
-			Value:  "n1-standard-4",
-			EnvVar: "CLOUDBRAIN_GCE_PREMIUM_MACHINE_TYPE",
-		},
-		cli.StringFlag{
-			Name:   "gce-network",
-			Usage:  "The GCE network to connect instances to",
-			Value:  "default",
-			EnvVar: "CLOUDBRAIN_GCE_NETWORK",
-		},
-		cli.IntFlag{
-			Name:   "gce-disk-size",
-			Usage:  "The GCE disk size in GiB",
-			Value:  30,
-			EnvVar: "CLOUDBRAIN_GCE_DISK_SIZE",
-		},
-		cli.BoolFlag{
-			Name:   "gce-auto-implode",
-			Usage:  "Enable to make the instance power off after gce-auto-implode-time if it's still running",
-			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE",
-		},
-		cli.DurationFlag{
-			Name:   "gce-auto-implode-time",
-			Usage:  "How long to wait before auto-imploding. Will be rounded down to the nearest minute.",
-			EnvVar: "CLOUDBRAIN_GCE_AUTO_IMPLODE_TIME",
-		},
-		cli.BoolFlag{
-			Name:   "gce-preemptible",
-			Usage:  "Enable to use GCE preemptible instances",
-			EnvVar: "CLOUDBRAIN_GCE_PREEMPTIBLE",
-		},
 		cli.DurationFlag{
 			Name:   "refresh-interval",
 			Usage:  "The interval at which to refresh the cached instances",
@@ -158,21 +98,14 @@ func mainAction(c *cli.Context) {
 	}
 	db := database.NewPostgresDB(pgdb)
 
-	provider, err := cloud.NewGCEProvider(cloud.GCEProviderConfiguration{
-		AccountJSON:         c.String("gce-account-json"),
-		ProjectID:           c.String("gce-project-id"),
-		ImageProjectID:      c.String("gce-image-project-id"),
-		Zone:                c.String("gce-zone"),
-		StandardMachineType: c.String("gce-standard-machine-type"),
-		PremiumMachineType:  c.String("gce-premium-machine-type"),
-		Network:             c.String("gce-network"),
-		DiskSize:            int64(c.Int("gce-disk-size")),
-		AutoImplode:         c.Bool("gce-auto-implode"),
-		AutoImplodeTime:     c.Duration("gce-auto-implode-time"),
-		Preemptible:         c.Bool("gce-preemptible"),
-	})
+	providers, err := db.ListProviders()
 	if err != nil {
-		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't create GCE provider")
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't get provider information from database")
+	}
+
+	provider, err := cloud.NewProvider(providers[0].Type, providers[0].Config)
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't create provider")
 	}
 
 	core := cloudbrain.NewCore(&cloudbrain.CoreConfig{

--- a/cmd/cloudbrain-refresh-worker/main.go
+++ b/cmd/cloudbrain-refresh-worker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"encoding/hex"
 	"os"
 	"time"
 
@@ -56,6 +57,11 @@ func main() {
 			Usage:  "The URL for the PostgreSQL database to use",
 			EnvVar: "CLOUDBRAIN_DATABASE_URL,DATABASE_URL",
 		},
+		cli.StringFlag{
+			Name:   "database-encryption-key",
+			Usage:  "The database encryption key, hex-encoded",
+			EnvVar: "CLOUDBRAIN_DATABASE_ENCRYPTION_KEY",
+		},
 		cli.DurationFlag{
 			Name:   "refresh-interval",
 			Usage:  "The interval at which to refresh the cached instances",
@@ -96,7 +102,15 @@ func mainAction(c *cli.Context) {
 	if err != nil {
 		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't connect to postgres")
 	}
-	db := database.NewPostgresDB(pgdb)
+
+	var encryptionKey [32]byte
+	keySlice, err := hex.DecodeString(c.String("database-encryption-key"))
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("couldn't decode database encryption key")
+	}
+	copy(encryptionKey[:], keySlice[0:32])
+
+	db := database.NewPostgresDB(encryptionKey, pgdb)
 
 	providers, err := db.ListProviders()
 	if err != nil {

--- a/database/database.go
+++ b/database/database.go
@@ -21,6 +21,9 @@ type DB interface {
 
 	// Insert a token into the database, returns the ID of the token
 	InsertToken(description string, hash, salt []byte) (uint64, error)
+
+	// List all the providers in the database
+	ListProviders() ([]Provider, error)
 }
 
 type Instance struct {
@@ -32,4 +35,10 @@ type Instance struct {
 	PublicSSHKey string
 	State        string
 	IPAddress    string
+}
+
+type Provider struct {
+	ID     string
+	Type   string
+	Config []byte
 }

--- a/database/database.go
+++ b/database/database.go
@@ -24,6 +24,10 @@ type DB interface {
 
 	// List all the providers in the database
 	ListProviders() ([]Provider, error)
+
+	// Inserts the provider into the database, returns the id or an error. The
+	// id will be automatically generated if one is not supplied.
+	CreateProvider(provider Provider) (string, error)
 }
 
 type Instance struct {

--- a/database/database.go
+++ b/database/database.go
@@ -44,5 +44,6 @@ type Instance struct {
 type Provider struct {
 	ID     string
 	Type   string
+	Name   string
 	Config []byte
 }

--- a/database/database.go
+++ b/database/database.go
@@ -32,8 +32,7 @@ type DB interface {
 
 type Instance struct {
 	ID           string
-	ProviderType string
-	ProviderID   string
+	ProviderName string
 	Image        string
 	InstanceType string
 	PublicSSHKey string

--- a/database/database.go
+++ b/database/database.go
@@ -12,9 +12,6 @@ type DB interface {
 	// Retrieves the instance by its ID, or returns an error
 	GetInstance(id string) (Instance, error)
 
-	// Retrieves the instance by its provider name and provider ID
-	GetInstanceByProviderID(provider, providerID string) (Instance, error)
-
 	// Updates the instance with the given ID
 	UpdateInstance(instance Instance) error
 
@@ -28,7 +25,7 @@ type DB interface {
 
 type Instance struct {
 	ID           string
-	Provider     string
+	ProviderType string
 	ProviderID   string
 	Image        string
 	InstanceType string

--- a/database/memory.go
+++ b/database/memory.go
@@ -89,3 +89,7 @@ func (db *MemoryDatabase) InsertToken(description string, hash, salt []byte) (ui
 func (db *MemoryDatabase) ListProviders() ([]Provider, error) {
 	return nil, fmt.Errorf("provider listing not implemented for MemoryDatabase")
 }
+
+func (db *MemoryDatabase) CreateProvider(provider Provider) (string, error) {
+	return "", fmt.Errorf("provider creation not implemented for MemoryDatabase")
+}

--- a/database/memory.go
+++ b/database/memory.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/pborman/uuid"
@@ -83,4 +84,8 @@ func (db *MemoryDatabase) InsertToken(description string, hash, salt []byte) (ui
 	})
 
 	return id, nil
+}
+
+func (db *MemoryDatabase) ListProviders() ([]Provider, error) {
+	return nil, fmt.Errorf("provider listing not implemented for MemoryDatabase")
 }

--- a/database/memory.go
+++ b/database/memory.go
@@ -50,19 +50,6 @@ func (db *MemoryDatabase) GetInstance(id string) (Instance, error) {
 	return instance, nil
 }
 
-func (db *MemoryDatabase) GetInstanceByProviderID(providerName, providerID string) (Instance, error) {
-	db.mutex.Lock()
-	defer db.mutex.Unlock()
-
-	for _, instance := range db.instances {
-		if instance.ProviderID == providerID && instance.Provider == providerName {
-			return instance, nil
-		}
-	}
-
-	return Instance{}, ErrInstanceNotFound
-}
-
 func (db *MemoryDatabase) UpdateInstance(instance Instance) error {
 	db.mutex.Lock()
 	defer db.mutex.Unlock()

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -113,3 +113,28 @@ func (db *PostgresDB) InsertToken(description string, hash, salt []byte) (uint64
 
 	return id, err
 }
+
+func (db *PostgresDB) ListProviders() ([]Provider, error) {
+	rows, err := db.db.Query("SELECT id, type, config FROM cloudbrain.providers")
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var providers []Provider
+	for rows.Next() {
+		var provider Provider
+		err := rows.Scan(&provider.ID, &provider.Type, &provider.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		providers = append(providers, provider)
+	}
+
+	if rows.Err() != nil {
+		return nil, rows.Err()
+	}
+
+	return providers, nil
+}

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -121,7 +121,7 @@ func (db *PostgresDB) InsertToken(description string, hash, salt []byte) (uint64
 }
 
 func (db *PostgresDB) ListProviders() ([]Provider, error) {
-	rows, err := db.db.Query("SELECT id, type, config FROM cloudbrain.providers")
+	rows, err := db.db.Query("SELECT id, type, name, config FROM cloudbrain.providers")
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func (db *PostgresDB) ListProviders() ([]Provider, error) {
 	for rows.Next() {
 		var provider Provider
 		var encryptedConfig []byte
-		err := rows.Scan(&provider.ID, &provider.Type, &encryptedConfig)
+		err := rows.Scan(&provider.ID, &provider.Type, &provider.Name, &encryptedConfig)
 		if err != nil {
 			return nil, err
 		}
@@ -160,9 +160,10 @@ func (db *PostgresDB) CreateProvider(provider Provider) (string, error) {
 	encryptedConfig := db.encrypt(provider.Config)
 
 	_, err := db.db.Exec(
-		"INSERT INTO cloudbrain.providers (id, type, config) VALUES ($1, $2, $3)",
+		"INSERT INTO cloudbrain.providers (id, type, name, config) VALUES ($1, $2, $3, $4)",
 		provider.ID,
 		provider.Type,
+		provider.Name,
 		encryptedConfig,
 	)
 	if err != nil {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -152,6 +152,26 @@ func (db *PostgresDB) ListProviders() ([]Provider, error) {
 	return providers, nil
 }
 
+func (db *PostgresDB) CreateProvider(provider Provider) (string, error) {
+	if provider.ID == "" {
+		provider.ID = uuid.New()
+	}
+
+	encryptedConfig := db.encrypt(provider.Config)
+
+	_, err := db.db.Exec(
+		"INSERT INTO cloudbrain.providers (id, type, config) VALUES ($1, $2, $3)",
+		provider.ID,
+		provider.Type,
+		encryptedConfig,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return provider.ID, nil
+}
+
 func (db *PostgresDB) decrypt(ciphertext []byte) ([]byte, bool) {
 	if len(ciphertext) < 24 {
 		return nil, false

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -26,10 +26,9 @@ func (db *PostgresDB) CreateInstance(instance Instance) (string, error) {
 	instance.ID = uuid.New()
 
 	_, err := db.db.Exec(
-		"INSERT INTO cloudbrain.instances (id, provider_type, provider_id, image, state, ip_address, ssh_key) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		"INSERT INTO cloudbrain.instances (id, provider_name, image, state, ip_address, ssh_key) VALUES ($1, $2, $3, $4, $5, $6, $7)",
 		instance.ID,
-		instance.ProviderType,
-		instance.ProviderID,
+		instance.ProviderName,
 		instance.Image,
 		instance.State,
 		sql.NullString{
@@ -52,11 +51,10 @@ func (db *PostgresDB) GetInstance(id string) (Instance, error) {
 	instance := Instance{ID: id}
 	var ipAddress, sshKey sql.NullString
 	err := db.db.QueryRow(
-		"SELECT provider_type, provider_id, image, state, ip_address, ssh_key FROM cloudbrain.instances WHERE id = $1",
+		"SELECT provider_name, image, state, ip_address, ssh_key FROM cloudbrain.instances WHERE id = $1",
 		id,
 	).Scan(
-		&instance.ProviderType,
-		&instance.ProviderID,
+		&instance.ProviderName,
 		&instance.Image,
 		&instance.State,
 		&ipAddress,
@@ -77,9 +75,8 @@ func (db *PostgresDB) GetInstance(id string) (Instance, error) {
 
 func (db *PostgresDB) UpdateInstance(instance Instance) error {
 	_, err := db.db.Exec(
-		"UPDATE cloudbrain.instances SET provider_type = $1, provider_id = $2, image = $3, state = $4, ip_address = $5, ssh_key = $6 WHERE id = $7",
-		instance.ProviderType,
-		instance.ProviderID,
+		"UPDATE cloudbrain.instances SET provider_name = $1, image = $2, state = $3, ip_address = $4, ssh_key = $5 WHERE id = $6",
+		instance.ProviderName,
 		instance.Image,
 		instance.State,
 		sql.NullString{

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -20,9 +20,9 @@ func (db *PostgresDB) CreateInstance(instance Instance) (string, error) {
 	instance.ID = uuid.New()
 
 	_, err := db.db.Exec(
-		"INSERT INTO cloudbrain.instances (id, provider, provider_id, image, state, ip_address, ssh_key) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+		"INSERT INTO cloudbrain.instances (id, provider_type, provider_id, image, state, ip_address, ssh_key) VALUES ($1, $2, $3, $4, $5, $6, $7)",
 		instance.ID,
-		instance.Provider,
+		instance.ProviderType,
 		instance.ProviderID,
 		instance.Image,
 		instance.State,
@@ -46,41 +46,11 @@ func (db *PostgresDB) GetInstance(id string) (Instance, error) {
 	instance := Instance{ID: id}
 	var ipAddress, sshKey sql.NullString
 	err := db.db.QueryRow(
-		"SELECT provider, provider_id, image, state, ip_address, ssh_key FROM cloudbrain.instances WHERE id = $1",
+		"SELECT provider_type, provider_id, image, state, ip_address, ssh_key FROM cloudbrain.instances WHERE id = $1",
 		id,
 	).Scan(
-		&instance.Provider,
+		&instance.ProviderType,
 		&instance.ProviderID,
-		&instance.Image,
-		&instance.State,
-		&ipAddress,
-		&sshKey,
-	)
-	if err == sql.ErrNoRows {
-		return Instance{}, ErrInstanceNotFound
-	}
-	if err != nil {
-		return Instance{}, err
-	}
-
-	instance.IPAddress = ipAddress.String
-	instance.PublicSSHKey = sshKey.String
-
-	return instance, nil
-}
-
-func (db *PostgresDB) GetInstanceByProviderID(providerName, providerID string) (Instance, error) {
-	instance := Instance{
-		Provider:   providerName,
-		ProviderID: providerID,
-	}
-	var ipAddress, sshKey sql.NullString
-	err := db.db.QueryRow(
-		"SELECT id, image, state, ip_address, ssh_key FROM cloudbrain.instances WHERE provider = $1 AND provider_id = $2",
-		providerName,
-		providerID,
-	).Scan(
-		&instance.ID,
 		&instance.Image,
 		&instance.State,
 		&ipAddress,
@@ -101,8 +71,8 @@ func (db *PostgresDB) GetInstanceByProviderID(providerName, providerID string) (
 
 func (db *PostgresDB) UpdateInstance(instance Instance) error {
 	_, err := db.db.Exec(
-		"UPDATE cloudbrain.instances SET provider = $1, provider_id = $2, image = $3, state = $4, ip_address = $5, ssh_key = $6 WHERE id = $7",
-		instance.Provider,
+		"UPDATE cloudbrain.instances SET provider_type = $1, provider_id = $2, image = $3, state = $4, ip_address = $5, ssh_key = $6 WHERE id = $7",
+		instance.ProviderType,
 		instance.ProviderID,
 		instance.Image,
 		instance.State,

--- a/sqitch/deploy/instances.sql
+++ b/sqitch/deploy/instances.sql
@@ -1,12 +1,11 @@
 -- Deploy cloudbrain:instances to pg
--- requires: appschema
+-- requires: appschema providers
 
 BEGIN;
 
 CREATE TABLE cloudbrain.instances (
 	id            uuid  PRIMARY KEY,
-	provider_type TEXT  NOT NULL,
-	provider_id   TEXT,
+	provider_name TEXT  NOT NULL REFERENCES cloudbrain.providers(name) ON UPDATE CASCADE,
 	image         TEXT  NOT NULL,
 	state         TEXT  NOT NULL,
 	ip_address    TEXT,

--- a/sqitch/deploy/instances.sql
+++ b/sqitch/deploy/instances.sql
@@ -4,13 +4,13 @@
 BEGIN;
 
 CREATE TABLE cloudbrain.instances (
-	id          uuid  PRIMARY KEY,
-	provider    TEXT  NOT NULL,
-	provider_id TEXT,
-	image       TEXT  NOT NULL,
-	state       TEXT  NOT NULL,
-	ip_address  TEXT,
-	ssh_key     TEXT
+	id            uuid  PRIMARY KEY,
+	provider_type TEXT  NOT NULL,
+	provider_id   TEXT,
+	image         TEXT  NOT NULL,
+	state         TEXT  NOT NULL,
+	ip_address    TEXT,
+	ssh_key       TEXT
 );
 
 COMMIT;

--- a/sqitch/deploy/providers.sql
+++ b/sqitch/deploy/providers.sql
@@ -5,6 +5,7 @@ BEGIN;
 
 CREATE TABLE cloudbrain.providers (
 	id uuid PRIMARY KEY,
+	name TEXT NOT NULL UNIQUE,
 	type TEXT NOT NULL,
 	config bytea NOT NULL
 );

--- a/sqitch/deploy/providers.sql
+++ b/sqitch/deploy/providers.sql
@@ -1,0 +1,12 @@
+-- Deploy cloudbrain:providers to pg
+-- requires: appschema
+
+BEGIN;
+
+CREATE TABLE cloudbrain.providers (
+	id uuid PRIMARY KEY,
+	type TEXT NOT NULL,
+	config bytea NOT NULL
+);
+
+COMMIT;

--- a/sqitch/revert/providers.sql
+++ b/sqitch/revert/providers.sql
@@ -1,0 +1,7 @@
+-- Revert cloudbrain:providers from pg
+
+BEGIN;
+
+DROP TABLE cloudbrain.providers;
+
+COMMIT;

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -5,3 +5,4 @@
 appschema 2016-03-01T23:01:20Z Henrik Hodne <henrik@travis-ci.org> # Add schema for all cloudbrain objects.
 instances [appschema] 2016-03-01T23:10:50Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track instances.
 auth_tokens [appschema] 2016-03-03T00:59:36Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track authentication tokens.
+providers [appschema] 2016-03-08T13:01:15Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track providers.

--- a/sqitch/sqitch.plan
+++ b/sqitch/sqitch.plan
@@ -3,6 +3,6 @@
 %uri=https://github.com/travis-ci/cloud-brain/
 
 appschema 2016-03-01T23:01:20Z Henrik Hodne <henrik@travis-ci.org> # Add schema for all cloudbrain objects.
-instances [appschema] 2016-03-01T23:10:50Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track instances.
 auth_tokens [appschema] 2016-03-03T00:59:36Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track authentication tokens.
 providers [appschema] 2016-03-08T13:01:15Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track providers.
+instances [appschema providers] 2016-03-01T23:10:50Z Henrik Hodne <henrik@travis-ci.org> # Creates table to track instances.

--- a/sqitch/verify/instances.sql
+++ b/sqitch/verify/instances.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-SELECT id, provider_type, provider_id, image, state, ip_address, ssh_key
+SELECT id, provider_name, image, state, ip_address, ssh_key
 FROM cloudbrain.instances
 WHERE false;
 

--- a/sqitch/verify/instances.sql
+++ b/sqitch/verify/instances.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-SELECT id, provider, provider_id, image, state, ip_address, ssh_key
+SELECT id, provider_type, provider_id, image, state, ip_address, ssh_key
 FROM cloudbrain.instances
 WHERE false;
 

--- a/sqitch/verify/providers.sql
+++ b/sqitch/verify/providers.sql
@@ -1,0 +1,9 @@
+-- Verify cloudbrain:providers on pg
+
+BEGIN;
+
+SELECT id, type, config
+FROM cloudbrain.providers
+WHERE false;
+
+ROLLBACK;

--- a/sqitch/verify/providers.sql
+++ b/sqitch/verify/providers.sql
@@ -2,7 +2,7 @@
 
 BEGIN;
 
-SELECT id, type, config
+SELECT id, type, name, config
 FROM cloudbrain.providers
 WHERE false;
 

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -34,6 +34,59 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/lib/pq",
+			"repository": "https://github.com/lib/pq",
+			"revision": "165a3529e799da61ab10faed1fabff3662d6193f",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/mitchellh/multistep",
+			"repository": "https://github.com/mitchellh/multistep",
+			"revision": "162146fc57112954184d90266f4733e900ed05a5",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/pborman/uuid",
+			"repository": "https://github.com/pborman/uuid",
+			"revision": "c55201b036063326c5b1b89ccfe45a184973d073",
+			"branch": "master"
+		},
+		{
+			"importpath": "golang.org/x/crypto/nacl/secretbox",
+			"repository": "https://go.googlesource.com/crypto",
+			"revision": "de93d05161db39bcbd84d3da2e54c4a18f37f0b1",
+			"branch": "master",
+			"path": "/nacl/secretbox"
+		},
+		{
+			"importpath": "golang.org/x/crypto/pbkdf2",
+			"repository": "https://go.googlesource.com/crypto",
+			"revision": "de93d05161db39bcbd84d3da2e54c4a18f37f0b1",
+			"branch": "master",
+			"path": "/pbkdf2"
+		},
+		{
+			"importpath": "golang.org/x/crypto/poly1305",
+			"repository": "https://go.googlesource.com/crypto",
+			"revision": "de93d05161db39bcbd84d3da2e54c4a18f37f0b1",
+			"branch": "master",
+			"path": "/poly1305"
+		},
+		{
+			"importpath": "golang.org/x/crypto/salsa20/salsa",
+			"repository": "https://go.googlesource.com/crypto",
+			"revision": "de93d05161db39bcbd84d3da2e54c4a18f37f0b1",
+			"branch": "master",
+			"path": "/salsa20/salsa"
+		},
+		{
+			"importpath": "golang.org/x/crypto/scrypt",
+			"repository": "https://go.googlesource.com/crypto",
+			"revision": "de93d05161db39bcbd84d3da2e54c4a18f37f0b1",
+			"branch": "master",
+			"path": "/scrypt"
+		},
+		{
 			"importpath": "golang.org/x/net/context",
 			"repository": "https://go.googlesource.com/net",
 			"revision": "6acef71eb69611914f7a30939ea9f6e194c78172",


### PR DESCRIPTION
I went back a forth quite a bit on how to implement this. In the end, I decided to store all the configuration in the database, and assign a name to each provider. Then, you pass in the provider name when creating the instance in the API, and it will use the corresponding provider.

I thought about grouping providers of the same type together, so you could just start an instance in the "gce" group and then Cloud Brain would figure out what provider to start it in (probably just pick one at random), but if we want to start putting the VMs behind a NAT without a public IP address, the worker needs to run in the same project, so the worker needs to specify which GCE project to boot the instance in. If it makes sense for future providers to group things together, we can add the option to pass in a provider name or a provider group name.

Closes #8.
