### PR TITLE
Retry initial redis connection for 10 seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-go: 1.6
+go: 1.7
 
 services:
 - redis

--- a/background/background.go
+++ b/background/background.go
@@ -14,6 +14,7 @@ import (
 // Backend is the interface that must be implemented by background worker
 // backends.
 type Backend interface {
+	WaitForConnection() error
 	Enqueue(job Job) error
 	FetchWork(queue string) (Job, error)
 	ScheduleAt(t time.Time, job Job) error

--- a/background/memory.go
+++ b/background/memory.go
@@ -19,6 +19,11 @@ func NewMemoryBackend() *MemoryBackend {
 	}
 }
 
+// WaitForConnection waits for the backing store to become available.
+func (mb *MemoryBackend) WaitForConnection() error {
+	return nil
+}
+
 // Enqueue pushes a job onto the given queue. Never returns an error.
 func (mb *MemoryBackend) Enqueue(job Job) error {
 	mb.jobsMutex.Lock()

--- a/background/redis.go
+++ b/background/redis.go
@@ -49,9 +49,9 @@ func (rb *RedisBackend) WaitForConnection() error {
 	maxRetries := 10
 	for i := 0; i < maxRetries; i++ {
 		conn := rb.pool.Get()
-		defer conn.Close()
+		err = conn.Err()
+		conn.Close()
 
-		_, err = conn.Do("PING")
 		if err == nil {
 			return nil
 		}

--- a/background/redis.go
+++ b/background/redis.go
@@ -55,7 +55,7 @@ func (rb *RedisBackend) WaitForConnection() error {
 		if err == nil {
 			return nil
 		}
-		time.Sleep(1)
+		time.Sleep(1 * time.Second)
 	}
 	return errors.Wrap(err, "could not connect to redis after 10 retries")
 }

--- a/cmd/cloudbrain-create-worker/main.go
+++ b/cmd/cloudbrain-create-worker/main.go
@@ -88,8 +88,12 @@ func mainAction(c *cli.Context) error {
 			return err
 		},
 	}
+
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
-	backgroundBackend.WaitForConnection()
+	err := backgroundBackend.WaitForConnection()
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("background backend creation failed")
+	}
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/cmd/cloudbrain-create-worker/main.go
+++ b/cmd/cloudbrain-create-worker/main.go
@@ -89,6 +89,7 @@ func mainAction(c *cli.Context) error {
 		},
 	}
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
+	backgroundBackend.WaitForConnection()
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/cmd/cloudbrain-http/main.go
+++ b/cmd/cloudbrain-http/main.go
@@ -102,6 +102,7 @@ func mainAction(c *cli.Context) error {
 		},
 	}
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
+	backgroundBackend.WaitForConnection()
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/cmd/cloudbrain-http/main.go
+++ b/cmd/cloudbrain-http/main.go
@@ -102,7 +102,10 @@ func mainAction(c *cli.Context) error {
 		},
 	}
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
-	backgroundBackend.WaitForConnection()
+	err := backgroundBackend.WaitForConnection()
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("background backend creation failed")
+	}
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/cmd/cloudbrain-refresh-worker/main.go
+++ b/cmd/cloudbrain-refresh-worker/main.go
@@ -95,6 +95,7 @@ func mainAction(c *cli.Context) error {
 		},
 	}
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
+	backgroundBackend.WaitForConnection()
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/cmd/cloudbrain-refresh-worker/main.go
+++ b/cmd/cloudbrain-refresh-worker/main.go
@@ -94,8 +94,12 @@ func mainAction(c *cli.Context) error {
 			return err
 		},
 	}
+
 	backgroundBackend := background.NewRedisBackend(redisPool, c.String("redis-worker-prefix"))
-	backgroundBackend.WaitForConnection()
+	err := backgroundBackend.WaitForConnection()
+	if err != nil {
+		cbcontext.LoggerFromContext(ctx).WithField("err", err).Fatal("background backend creation failed")
+	}
 
 	if c.String("database-url") == "" {
 		cbcontext.LoggerFromContext(ctx).Fatal("database-url flag is required")

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -76,6 +76,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/pkg/errors",
+			"repository": "https://github.com/pkg/errors",
+			"vcs": "git",
+			"revision": "17b591df37844cde689f4d5813e5cea0927d8dd2",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "golang.org/x/crypto/nacl/secretbox",
 			"repository": "https://go.googlesource.com/crypto",
 			"vcs": "",


### PR DESCRIPTION
We were running into some issues where stunnel (that sits in front of redis) was starting too slowly, and the connection could not be established, leading to some of the background tasks crashing.
