### PR TITLE
support defining the token via basic auth, to allow for .netrc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,3 +120,23 @@ Status: 200 OK
 	"state": "running"
 }
 ```
+
+## Usage (script)
+
+There is a nice client script that you can use to interact with the API. It uses [httpie](https://github.com/jkbrzt/httpie).
+
+Since httpie supports `~/.netrc` files for authentication, you can create such a file (if it does not already exist), and configure it with your cloud-brain token as follows:
+
+```
+machine travis-cloud-brain-staging.herokuapp.com
+  login token
+  password 0-your-very-secret-cloud-brain-token
+```
+
+Example:
+
+```bash
+$ script/cloud-brain-staging post instances provider=gce-staging image=travis-ci-amethyst-trusty-1470801111 instance_type=standard
+$ script/cloud-brain-staging get instances/6f6466f9-b99b-4b7f-b446-6d85ce4c8958
+$ script/cloud-brain-staging delete instances/6f6466f9-b99b-4b7f-b446-6d85ce4c8958
+```

--- a/script/cloud-brain-staging
+++ b/script/cloud-brain-staging
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+BASE_URL=http://travis-cloud-brain-staging.herokuapp.com
+case "$1" in
+  get|put|post|delete|options|head)
+    METHOD="$1"
+    shift
+    ;;
+  *)
+    METHOD=get
+    ;;
+esac
+REQUEST_PATH="$1"
+shift
+
+http "$METHOD" "$BASE_URL/$REQUEST_PATH" $@


### PR DESCRIPTION
Lots of http clients (e.g. httpie) support a ~/.netrc file, that can look
like this:

```
machine travis-cloud-brain-staging.herokuapp.com
  login token
  password 0-very-secret-token
```
