### PR TITLE
No longer delete instances from db, update state to terminating, terminated instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ PACKAGES := \
 	github.com/travis-ci/cloud-brain/cmd/cloudbrain-create-worker \
 	github.com/travis-ci/cloud-brain/cmd/cloudbrain-http \
 	github.com/travis-ci/cloud-brain/cmd/cloudbrain-refresh-worker \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-remove-worker \
+	github.com/travis-ci/cloud-brain/cmd/cloudbrain-show-provider \
 	github.com/travis-ci/cloud-brain/database \
 	github.com/travis-ci/cloud-brain/http
 

--- a/cloud/gce.go
+++ b/cloud/gce.go
@@ -177,7 +177,7 @@ func NewGCEProvider(conf GCEProviderConfiguration) (*GCEProvider, error) {
 	}, nil
 }
 
-// List returns a list of all instances on Google Compute Engine that was\
+// List returns a list of all instances on Google Compute Engine that were
 // created by Cloud Brain.
 func (p *GCEProvider) List() ([]Instance, error) {
 	instanceList, err := p.client.Instances.List(p.projectID, p.ic.Zone.Name).Filter("name eq ^testing-gce-.+").Do()

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -147,9 +147,8 @@ func (c *Core) RemoveInstance(ctx context.Context, attr DeleteInstanceAttributes
 		return errors.Wrap(err, "error fetching instance from DB")
 	}
 
-	_, err = c.db.RemoveInstance(inst)
-	if err != nil {
-		return errors.Wrap(err, "error deleting instance in database")
+	if inst.State == "terminating" || inst.State == "terminated" {
+		return errors.Wrapf(err, "not removing instance, state is already %s", inst.State)
 	}
 
 	err = c.bb.Enqueue(background.Job{

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -257,7 +257,7 @@ func (c *Core) ProviderRemoveInstance(ctx context.Context, byteID []byte) error 
 	}
 
 	dbInstance.State = "terminating"
-	err = db.UpdateInstance(dbInstance)
+	err = c.db.UpdateInstance(dbInstance)
 	if err != nil {
 		return errors.Wrap(err, "error updating instance state to terminating in DB")
 	}

--- a/cloudbrain/core.go
+++ b/cloudbrain/core.go
@@ -256,6 +256,12 @@ func (c *Core) ProviderRemoveInstance(ctx context.Context, byteID []byte) error 
 		return err
 	}
 
+	dbInstance.State = "terminating"
+	err = db.UpdateInstance(dbInstance)
+	if err != nil {
+		return errors.Wrap(err, "error updating instance state to terminating in DB")
+	}
+
 	cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
 		"instance_id": id,
 	}).Info("removed instance")
@@ -279,7 +285,11 @@ func (c *Core) ProviderRefresh(ctx context.Context) error {
 			continue
 		}
 
+		seenIds := make(map[string]bool)
+
 		for _, instance := range instances {
+			seenIds[instance.ID] = true
+
 			dbInstance, err := c.db.GetInstance(instance.ID)
 			if err != nil {
 				cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
@@ -303,6 +313,34 @@ func (c *Core) ProviderRefresh(ctx context.Context) error {
 					"provider_id": instance.ID,
 					"db_id":       dbInstance.ID,
 				}).Error("failed to update instance in database")
+			}
+		}
+
+		terminatingDbInstances, err := c.db.GetInstancesByState("terminating")
+		if err != nil {
+			cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+				"err":      err,
+				"provider": providerName,
+			}).Error("failed to fetch list of terminating instances")
+			continue
+		}
+
+		// find instances that were in terminating state
+		// if the id is no longer in seenIds, it was deleted
+		// from GCE, we can now consider it terminated
+		for _, dbInstance := range terminatingDbInstances {
+			_, found := seenIds[dbInstance.ID]
+			if !found {
+				dbInstance.State = "terminated"
+
+				err = c.db.UpdateInstance(dbInstance)
+				if err != nil {
+					cbcontext.LoggerFromContext(ctx).WithFields(logrus.Fields{
+						"err":      err,
+						"provider": providerName,
+						"db_id":    dbInstance.ID,
+					}).Error("failed to update instance in database")
+				}
 			}
 		}
 

--- a/database/database.go
+++ b/database/database.go
@@ -18,6 +18,9 @@ type DB interface {
 	// Retrieves the instance by its ID, or returns an error
 	GetInstance(id string) (Instance, error)
 
+	// Retrieves all instances by State
+	GetInstancesByState(state string) ([]Instance, error)
+
 	// Updates the instance with the given ID
 	UpdateInstance(instance Instance) error
 

--- a/database/memory.go
+++ b/database/memory.go
@@ -71,6 +71,21 @@ func (db *MemoryDatabase) GetInstance(id string) (Instance, error) {
 	return instance, nil
 }
 
+// GetInstancesByState returns a slice of instances for a given state
+func (db *MemoryDatabase) GetInstancesByState(state string) ([]Instance, error) {
+	db.mutex.Lock()
+	defer db.mutex.Unlock()
+
+	var instances []Instance
+	for _, instance := range db.instances {
+		if instance.State == state {
+			instances = append(instances, instance)
+		}
+	}
+
+	return instances, nil
+}
+
 // UpdateInstance updates the instance with the given ID, or returns
 // ErrInstanceNotFound if no instance with that ID exists.
 func (db *MemoryDatabase) UpdateInstance(instance Instance) error {

--- a/database/postgres.go
+++ b/database/postgres.go
@@ -115,7 +115,7 @@ func (db *PostgresDB) GetInstance(id string) (Instance, error) {
 func (db *PostgresDB) GetInstancesByState(state string) ([]Instance, error) {
 	var instances []Instance
 
-	rows, err := db.db.Query("SELECT provider_name, image, state, ip_address, ssh_key, upstream_id, error_reason FROM cloudbrain.instances WHERE state = $1", state)
+	rows, err := db.db.Query("SELECT id, provider_name, image, state, ip_address, ssh_key, upstream_id, error_reason FROM cloudbrain.instances WHERE state = $1", state)
 	if err != nil {
 		return instances, err
 	}
@@ -123,6 +123,7 @@ func (db *PostgresDB) GetInstancesByState(state string) ([]Instance, error) {
 		instance := &Instance{}
 		var ipAddress, sshKey, upstreamID, errorReason sql.NullString
 		err := rows.Scan(
+			&instance.ID,
 			&instance.ProviderName,
 			&instance.Image,
 			&instance.State,

--- a/http/handler.go
+++ b/http/handler.go
@@ -55,10 +55,7 @@ func respondError(ctx context.Context, w http.ResponseWriter, status int, err er
 }
 
 func respondOk(ctx context.Context, w http.ResponseWriter, body interface{}) {
-	w.Header().Add("Content-Type", "application/json")
-
 	var status int
-
 	if body == nil {
 		status = http.StatusNoContent
 	} else {

--- a/http/handler.go
+++ b/http/handler.go
@@ -42,6 +42,7 @@ func parseRequest(ctx context.Context, r *http.Request, out interface{}) error {
 
 func respondError(ctx context.Context, w http.ResponseWriter, status int, err error) {
 	cbcontext.LoggerFromContext(ctx).WithField("response", status).WithField("err", err).Info()
+
 	w.Header().Add("Content-Type", "application/json")
 	w.WriteHeader(status)
 
@@ -56,13 +57,22 @@ func respondError(ctx context.Context, w http.ResponseWriter, status int, err er
 func respondOk(ctx context.Context, w http.ResponseWriter, body interface{}) {
 	w.Header().Add("Content-Type", "application/json")
 
-	status := http.StatusNoContent
+	var status int
 
 	if body == nil {
-		w.WriteHeader(status)
+		status = http.StatusNoContent
 	} else {
 		status = http.StatusOK
-		w.WriteHeader(status)
+	}
+
+	respondStatus(ctx, w, status, body)
+}
+
+func respondStatus(ctx context.Context, w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Add("Content-Type", "application/json")
+	w.WriteHeader(status)
+
+	if body != nil {
 		json.NewEncoder(w).Encode(body)
 	}
 

--- a/http/instances.go
+++ b/http/instances.go
@@ -59,6 +59,11 @@ func handleInstancesGet(ctx context.Context, core *cloudbrain.Core, w http.Respo
 		return
 	}
 
+	if instance.State == "terminated" {
+		respondStatus(ctx, w, http.StatusGone, instanceToResponse(instance))
+		return
+	}
+
 	respondOk(ctx, w, instanceToResponse(instance))
 }
 


### PR DESCRIPTION
The first issue being addressed is us deleting the instance from the database, which means the delete worker cannot actually pick up the instance. We could move the deletion logic into the worker, but it is actually nicer to keep the db instance around and have a periodic cleanup, this provides us with more auditing capabilities. As a bonus, we return a 410 Gone for a terminated instance now.

Because we terminate and delete instances in one step on GCE, this means refresh worker may not pick up the new state of `terminating` or `terminating` (since the instance no longer exists in the cloud). For this reason the refresh will check for instances with state `terminating` that no longer exist. These are then updated to `terminated`.
